### PR TITLE
Addresses "Getting AccessDenied for redirect domain"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,12 +271,17 @@ resource "aws_cloudfront_distribution" "website_cdn_redirect" {
 
   origin {
     origin_id   = "origin-bucket-${aws_s3_bucket.website_redirect.id}"
-    domain_name = aws_s3_bucket.website_redirect.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.website_redirect.website_endpoint
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity_website.cloudfront_access_identity_path
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_keepalive_timeout = 5
+      origin_protocol_policy   = "http-only"
+      origin_read_timeout      = 30
+      origin_ssl_protocols     = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      }
     }
-  }
 
   default_root_object = "index.html"
 


### PR DESCRIPTION
As pointed out by @marcusbelcher, using the redirect bucket's website endpoint appears to fix the problem.

Unlike @jakobpin's solution this works for me without having to make the bucket public.

Addresses https://github.com/cloudmaniac/terraform-aws-static-website/issues/1

(it's like a bus - you wait for ages then 2 come along at once)