### PR TITLE
Improvement to redirect behaviour

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -274,8 +274,6 @@ resource "aws_cloudfront_distribution" "website_cdn_redirect" {
     }
   }
 
-  default_root_object = "index.html"
-
   logging_config {
     bucket = aws_s3_bucket.website_logs.bucket_domain_name
     prefix = "${var.website-domain-redirect}/"


### PR DESCRIPTION
Setting cloudfront's `default_root_object` to "index.html" seems to have the effect that `https://www.{domain}/` redirects to `https://{domain}/index.html` which works but isn't ideal. Removing `default_root_object` solves this, however there may be other considerations of which I'm not aware.