### PR TITLE
Optional support for Lambdas

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -199,6 +199,14 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
       }
     }
 
+    # An optional AWS Lambda Function for customising CloudFront behaviour.
+    dynamic "lambda_function_association" {
+      for_each = var.cloudfront_lambda_function_arn == null ? [] : [1]
+      content {
+        event_type = var.cloudfront_lambda_function_event_type
+        lambda_arn = var.cloudfront_lambda_function_arn
+      }
+    }
   }
 
   restrictions {

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,22 @@ variable "tags" {
   default     = {}
   type        = map(string)
 }
+
+variable "cloudfront_lambda_function_arn" {
+  description = <<EOF
+                The optional ARN of AWS Lambda Function that can be associated with the CloudFront
+                distribution that can provide custom behaviour. For more information read:
+                https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_function_association
+                EOF
+  default     = null
+  type        = string
+}
+
+variable "cloudfront_lambda_function_event_type" {
+  description = <<EOF
+                The type of event that triggers the above Lambda Function. For possible types, see:
+                https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_function_association
+                EOF
+  default     = "origin-request"
+  type        = string
+}


### PR DESCRIPTION
I understand from the TODO list that you intend to re-introduce the Lambda@Edge index rewriting function at some point. However, in the meantime (for back compatibility), it would be useful to allow an optional association with a Lambda defined externally to the module. To this end, I've added an optional module variable to allow you to do this.
