### PR TITLE
split out zone root from domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 ## Route 53
 # Provides details about the zone
 data "aws_route53_zone" "main" {
-  name         = var.website-domain-main
+  name         = var.domains-zone-root
   private_zone = false
 }
 
@@ -351,3 +351,4 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,15 @@ variable "website-domain-redirect" {
   type        = string
 }
 
+variable "domains-zone-root" {
+  description = "root zone under which the domains should be registered"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags added to resources"
   default     = {}
   type        = map(string)
 }
+


### PR DESCRIPTION
possible solution to #8 

to keep reusing `website-domain-main` as `domains-zone-root`, I believe the variables would have to be split unto a separate module that could output `domains-zone-root` with either `website-domain-main` or an overridden value