### PR TITLE
Add support for SPA sites with custom_error_response

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For that reason, the module includes an aliased provider definition to create su
 |------|-------------|:----:|:-------:|:--------:|
 | website-domain-main | Domain for the website (e.g., `example.com`) | string | - | yes |
 | website-domain-redirect | Alternate subdomain to redirect to the main website (e.g., `www.example.com`) | string | - | yes |
+| support-spa | Determine if website is SPA to direct 404 response to index.html | bool | false | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For that reason, the module includes an aliased provider definition to create su
 |------|-------------|:----:|:-------:|:--------:|
 | website-domain-main | Domain for the website (e.g., `example.com`) | string | - | yes |
 | website-domain-redirect | Alternate subdomain to redirect to the main website (e.g., `www.example.com`) | string | - | yes |
-| support-spa | Determine if website is SPA to direct 404 response to index.html | bool | false | no |
+| support-spa | Determine if website is SPA (Single-Page Application) to direct 404 response to index.html | bool | false | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 ## Route 53
 # Provides details about the zone
 data "aws_route53_zone" "main" {
-  name         = var.website-domain-main
+  name         = var.domains-zone-root
   private_zone = false
 }
 
@@ -351,3 +351,4 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -215,8 +215,8 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
   custom_error_response {
     error_caching_min_ttl = 300
     error_code            = 404
-    response_page_path    = "/404.html"
-    response_code         = 404
+    response_page_path    = var.support-spa ? "/index.html" : "/404.html"
+    response_code         = var.support-spa ? 200 : 404
   }
 
   tags = merge(var.tags, {
@@ -294,14 +294,6 @@ resource "aws_cloudfront_distribution" "website_cdn_redirect" {
   logging_config {
     bucket = aws_s3_bucket.website_logs.bucket_domain_name
     prefix = "${var.website-domain-redirect}/"
-  }
-  dynamic "custom_error_response" {
-    for_each = var.support-spa ? [{"key" = "value"}] : []
-    content {
-      error_code = 404
-      response_code = 200
-      response_page_path = "/index.html"
-    }
   }
 
   default_cache_behavior {

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_s3_bucket" "website_root" {
 
   website {
     index_document = "index.html"
-    error_document = "404.html"
+    error_document = var.support-spa ? "" : "404.html"
   }
 
   tags = merge(var.tags, {
@@ -294,6 +294,14 @@ resource "aws_cloudfront_distribution" "website_cdn_redirect" {
   logging_config {
     bucket = aws_s3_bucket.website_logs.bucket_domain_name
     prefix = "${var.website-domain-redirect}/"
+  }
+  dynamic "custom_error_response" {
+    for_each = var.support-spa ? [{"key" = "value"}] : []
+    content {
+      error_code = 404
+      response_code = 200
+      response_page_path = "/index.html"
+    }
   }
 
   default_cache_behavior {

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,8 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "support-spa" {
+  description = "Support SPA website with redirect to index.html"
+  default = false
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,15 @@ variable "website-domain-redirect" {
   type        = string
 }
 
+variable "domains-zone-root" {
+  description = "root zone under which the domains should be registered"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags added to resources"
   default     = {}
   type        = map(string)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -24,5 +24,5 @@ variable "tags" {
 variable "support-spa" {
   description = "Support SPA website with redirect to index.html"
   default = false
-  type = string
+  type = bool
 }


### PR DESCRIPTION
- My branch is based on https://github.com/cloudmaniac/terraform-aws-static-website/pull/10 as subdomain is my use case
- Add support for SPA sites with custom_error_response
- Ran and tested on my infra